### PR TITLE
 Destroy orphan cells before initializing new cells

### DIFF
--- a/src/Builder.js
+++ b/src/Builder.js
@@ -47,6 +47,8 @@ export default {
 
     this.activeCells = found;
 
+    this.destroyOrphans(previous, found);
+
     found.forEach(cell => {
       if (cell.initialized) {
         cell.reload(cell.element);
@@ -55,8 +57,6 @@ export default {
       cell.initialized = true;
       cell.initialize && cell.initialize(cell.element);
     });
-
-    this.destroyOrphans(previous, found);
   },
 
   /**

--- a/tests/Builder.test.js
+++ b/tests/Builder.test.js
@@ -93,6 +93,7 @@ describe("Builder", () => {
 
       expect(existingCell.reload).to.have.been.called;
       expect(newCell.initialize).to.have.been.called;
+      expect(newCell.initialize).have.been.calledAfter(destroyOrphans);
 
       findAndBuild.restore();
       destroyOrphans.restore();


### PR DESCRIPTION
We're using [Phoenix Channels](https://hexdocs.pm/phoenix/channels.html) to update content:

```js
this.channel = socket.channel(topic);
this.channel.on("update", this.onUpdate);

onUpdate = result => {
  this.element.outerHTML = result.cell_html;
  Builder.reload();
};
```

After updating `this.element` and calling `Builder.reload()` the cell is initialized and then destroyed. This results in `onDestroy` hook being called after `initialize`, meaning the teardown logic is applied to the new (reloaded) cell.

This PR changes the the order: destroy old cells before init new cells. This fixes the issue described above, but I'm not sure if this will have side effects in other cases.

@jessedijkstra what do you think? Does this makes sense to you?
