### PR TITLE
Initialize cells only once

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defacto/cell-js",
-  "version": "0.0.18",
+  "version": "1.0.0",
   "description":
     "Simple solution for binding Javascript to specific templates or side server components",
   "main": "dist/",

--- a/src/Builder.js
+++ b/src/Builder.js
@@ -38,8 +38,7 @@ export default {
   },
 
   /**
-   * Inititialize new cells, teardown the removed cells and reload existing
-   * cells.
+   * Inititialize new cells, teardown the removed cells and reload existing cells
    */
   reload() {
     const found = this.findAndBuild();
@@ -52,10 +51,10 @@ export default {
     found.forEach(cell => {
       if (cell.initialized) {
         cell.reload(cell.element);
+      } else {
+        cell.initialize && cell.initialize(cell.element);
+        cell.initialized = true;
       }
-
-      cell.initialized = true;
-      cell.initialize && cell.initialize(cell.element);
     });
   },
 


### PR DESCRIPTION
At the moment when calling `Builder.reload()`, cells are being re-initialized (without being destroyed).
This can cause unwanted side-effects, for example when adding event listeners during init which then will get fired multiple times.

@jessedijkstra does this change makes sense to you?